### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,12 @@
 				       an HTTP Request far away
 
 [![Build Status](https://travis-ci.org/CognitionGuidedSurgery/restflow.svg?branch=master)](https://travis-ci.org/CognitionGuidedSurgery/restflow)
-[![Downloads](https://pypip.in/download/restflow/badge.svg)](https://pypi.python.org/pypi/restflow/)
-[![Latest Version](https://pypip.in/version/restflow/badge.svg)](https://pypi.python.org/pypi/restflow/)
-[![Supported Python versions](https://pypip.in/py_versions/restflow/badge.svg)](https://pypi.python.org/pypi/restflow/)
-[![Development Status](https://pypip.in/status/restflow/badge.svg)](https://pypi.python.org/pypi/restflow/)
-[![Download format](https://pypip.in/format/restflow/badge.svg)](https://pypi.python.org/pypi/restflow/)
-[![License](https://pypip.in/license/restflow/badge.svg)](https://pypi.python.org/pypi/restflow/)
+[![Downloads](https://img.shields.io/pypi/dm/restflow.svg
+[![Latest Version](https://img.shields.io/pypi/v/restflow.svg
+[![Supported Python versions](https://img.shields.io/pypi/pyversions/restflow.svg
+[![Development Status](https://img.shields.io/pypi/status/restflow.svg
+[![Download format](https://img.shields.io/pypi/format/restflow.svg
+[![License](https://img.shields.io/pypi/l/restflow.svg
 
     Author: Alexander Weigl <Alexander.Weigl@student.kit.edu>
             Nicolai Schoch <Nicolai.Schoch@iwr.uni-heidelberg.de>

--- a/README.md
+++ b/README.md
@@ -9,12 +9,11 @@
 				       an HTTP Request far away
 
 [![Build Status](https://travis-ci.org/CognitionGuidedSurgery/restflow.svg?branch=master)](https://travis-ci.org/CognitionGuidedSurgery/restflow)
-[![Downloads](https://img.shields.io/pypi/dm/restflow.svg
-[![Latest Version](https://img.shields.io/pypi/v/restflow.svg
-[![Supported Python versions](https://img.shields.io/pypi/pyversions/restflow.svg
-[![Development Status](https://img.shields.io/pypi/status/restflow.svg
-[![Download format](https://img.shields.io/pypi/format/restflow.svg
-[![License](https://img.shields.io/pypi/l/restflow.svg
+[![Latest Version](https://img.shields.io/pypi/v/restflow.svg)](https://pypi.python.org/pypi/restflow/)
+[![Supported Python versions](https://img.shields.io/pypi/pyversions/restflow.svg)](https://pypi.python.org/pypi/restflow/)
+[![Development Status](https://img.shields.io/pypi/status/restflow.svg)](https://pypi.python.org/pypi/restflow/)
+[![Download format](https://img.shields.io/pypi/format/restflow.svg)](https://pypi.python.org/pypi/restflow/)
+[![License](https://img.shields.io/pypi/l/restflow.svg)](https://pypi.python.org/pypi/restflow/)
 
     Author: Alexander Weigl <Alexander.Weigl@student.kit.edu>
             Nicolai Schoch <Nicolai.Schoch@iwr.uni-heidelberg.de>


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20restflow))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `restflow`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.

Unfortunately, [PyPI has removed download statistics from their API](https://mail.python.org/pipermail/distutils-sig/2013-May/020855.html), which means that even the shields.io "download count" badges are broken (they display "no longer available". See [this](https://github.com/badges/shields/issues/716)). So those badges should really be removed entirely. Since this is an automated process (and trying to automatically remove the badges from READMEs can be tricky), this pull request just replaces the URL with the shields.io syntax.